### PR TITLE
dev into main

### DIFF
--- a/public/images/logo.svg
+++ b/public/images/logo.svg
@@ -1,0 +1,5 @@
+<svg width="512" height="512" viewBox="0 0 512 512" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect x="90" y="90" width="68" height="200" rx="12" fill="#121212"/>
+<rect x="422" y="354" width="68" height="200" rx="12" transform="rotate(90 422 354)" fill="#121212"/>
+<circle cx="124" cy="386" r="34" fill="#F3331B"/>
+</svg>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -172,3 +172,82 @@
 .prose img {
   @apply max-w-full h-auto;
 }
+
+/* 홈 3D 명함 초기 로딩 모션 (favicon 로고) */
+/* 세로 막대(상→하) → 가로 막대(우→좌) 그리기 후, 빨간 점 팝업 + 펄스 */
+@keyframes bc-draw-v {
+  from {
+    transform: scaleY(0);
+  }
+  to {
+    transform: scaleY(1);
+  }
+}
+@keyframes bc-draw-h {
+  from {
+    transform: scaleX(0);
+  }
+  to {
+    transform: scaleX(1);
+  }
+}
+@keyframes bc-pop-in {
+  from {
+    transform: scale(0);
+  }
+  to {
+    transform: scale(1);
+  }
+}
+@keyframes bc-pulse {
+  0%,
+  100% {
+    transform: scale(1);
+  }
+  50% {
+    transform: scale(1.14);
+  }
+}
+
+.bc-loader {
+  --dur: 0.9s;
+}
+.bc-loader .bar-v,
+.bc-loader .bar-h,
+.bc-loader .dot {
+  transform-box: fill-box;
+  transform: scale(0);
+}
+.bc-loader .bar-v,
+.bc-loader .bar-h {
+  fill: var(--foreground);
+}
+.bc-loader .dot {
+  fill: var(--accent-foreground);
+}
+.bc-loader .bar-v {
+  transform-origin: top center;
+  animation: bc-draw-v calc(var(--dur) * 0.4) cubic-bezier(0.22, 1, 0.36, 1) both;
+}
+.bc-loader .bar-h {
+  transform-origin: right center;
+  /* 세로 막대와 동시에 그려짐 (delay 없음) */
+  animation: bc-draw-h calc(var(--dur) * 0.4) cubic-bezier(0.22, 1, 0.36, 1) both;
+}
+.bc-loader .dot {
+  transform-origin: center;
+  /* 막대(0.4)가 다 그려진 직후 팝업(~0.74에 완료), 그 후 펄스 */
+  animation:
+    bc-pop-in calc(var(--dur) * 0.34) cubic-bezier(0.34, 1.56, 0.64, 1)
+      calc(var(--dur) * 0.4) both,
+    bc-pulse calc(var(--dur) * 1.15) ease-in-out calc(var(--dur) * 0.74) infinite;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .bc-loader .bar-v,
+  .bc-loader .bar-h,
+  .bc-loader .dot {
+    transform: scale(1);
+    animation: none;
+  }
+}

--- a/src/components/home/BusinessCard.tsx
+++ b/src/components/home/BusinessCard.tsx
@@ -13,26 +13,35 @@ import {
 } from '@/lib/constants/businessCard'
 import { Canvas, useFrame, useLoader, useThree } from '@react-three/fiber'
 import { Html, OrbitControls } from '@react-three/drei'
-import { Suspense, useMemo, useRef } from 'react'
+import { Suspense, useEffect, useMemo, useRef } from 'react'
 
 import { getCardScale } from '@/lib/utils/responsive'
 
-export default function BusinessCardCanvas() {
+export default function BusinessCardCanvas({
+  onReady,
+}: {
+  onReady?: () => void
+}) {
   return (
     <div className="h-[80vh] w-full">
       <Canvas camera={{ position: [0, 0, 15], fov: 30 }}>
         <ambientLight />
-        <BusinessCard />
+        <BusinessCard onReady={onReady} />
         <OrbitControls enableZoom={false} />
       </Canvas>
     </div>
   )
 }
 
-function BusinessCard() {
+function BusinessCard({ onReady }: { onReady?: () => void }) {
   const meshRef = useRef<THREE.Mesh>(null)
   const texture = useLoader(THREE.TextureLoader, TEXTURE_PATH)
   const { viewport } = useThree()
+
+  // 텍스처 로드가 끝나 이 컴포넌트가 렌더되면(=3D 준비 완료) 부모에 알림
+  useEffect(() => {
+    onReady?.()
+  }, [onReady])
 
   const responsiveScale = useMemo((): [number, number, 0.01] => {
     const deviceWidth =

--- a/src/components/home/BusinessCardLoader.tsx
+++ b/src/components/home/BusinessCardLoader.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import dynamic from 'next/dynamic'
-import { useEffect, useState } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 
 import { CardLoadingMotion } from '@/components/home/CardLoadingMotion'
 import { Spinner } from '@/components/ui/spinner'
@@ -45,13 +45,15 @@ export default function BusinessCardLoader() {
     return () => clearTimeout(timer)
   }, [firstLoad])
 
+  const handleReady = useCallback(() => setReady(true), [])
+
   // 최초 로드에만, 최소 노출 시간과 3D 준비가 모두 끝날 때까지 모션을 유지한다.
   // (스피너가 드러날 틈이 없도록 오버레이가 준비 완료까지 덮음)
   const showMotion = firstLoad && !(minElapsed && ready)
 
   return (
     <>
-      <BusinessCardCanvas onReady={() => setReady(true)} />
+      <BusinessCardCanvas onReady={handleReady} />
       {showMotion && <CardLoadingMotion />}
     </>
   )

--- a/src/components/home/BusinessCardLoader.tsx
+++ b/src/components/home/BusinessCardLoader.tsx
@@ -1,12 +1,58 @@
 'use client'
 
 import dynamic from 'next/dynamic'
+import { useEffect, useState } from 'react'
+
+import { CardLoadingMotion } from '@/components/home/CardLoadingMotion'
+import { Spinner } from '@/components/ui/spinner'
+
+/** 로딩 모션 최소 노출 시간(ms). 막대 그리기 + 원 팝업 완료 시점(템포 0.9s 기준 약 0.666s). */
+const MIN_VISIBLE_MS = 666
+
+/**
+ * 이 세션(페이지 로드)에서 홈을 이미 봤는지.
+ * 모듈 스코프라 SPA 네비게이션엔 유지되고, 하드 새로고침에만 리셋된다.
+ */
+let seenHome = false
 
 const BusinessCardCanvas = dynamic(
   () => import('@/components/home/BusinessCard'),
-  { ssr: false },
+  {
+    ssr: false,
+    // 번들 캐시 후(재방문)엔 거의 뜨지 않음. 명함 자리에 가벼운 스피너.
+    loading: () => (
+      <div className="flex h-[80vh] w-full items-center justify-center">
+        <Spinner className="size-6 text-muted-foreground" />
+      </div>
+    ),
+  },
 )
 
+/**
+ * 홈 3D 명함을 클라이언트에서만(dynamic, ssr:false) 로드한다.
+ * - 최초 로드: 풀스크린 로고 모션을 최소 노출 시간(약 0.666s)만큼 덮어, 무거운 번들 로딩/워밍업을 가림
+ * - 재방문(SPA): 번들이 캐시돼 즉시 렌더되므로 모션 없이 바로 표시(필요 시 명함 자리 스피너)
+ */
 export default function BusinessCardLoader() {
-  return <BusinessCardCanvas />
+  const [firstLoad] = useState(() => !seenHome)
+  const [minElapsed, setMinElapsed] = useState(false)
+  const [ready, setReady] = useState(false)
+
+  useEffect(() => {
+    seenHome = true
+    if (!firstLoad) return
+    const timer = setTimeout(() => setMinElapsed(true), MIN_VISIBLE_MS)
+    return () => clearTimeout(timer)
+  }, [firstLoad])
+
+  // 최초 로드에만, 최소 노출 시간과 3D 준비가 모두 끝날 때까지 모션을 유지한다.
+  // (스피너가 드러날 틈이 없도록 오버레이가 준비 완료까지 덮음)
+  const showMotion = firstLoad && !(minElapsed && ready)
+
+  return (
+    <>
+      <BusinessCardCanvas onReady={() => setReady(true)} />
+      {showMotion && <CardLoadingMotion />}
+    </>
+  )
 }

--- a/src/components/home/CardLoadingMotion.tsx
+++ b/src/components/home/CardLoadingMotion.tsx
@@ -5,13 +5,15 @@
  */
 export function CardLoadingMotion() {
   return (
-    <div className="fixed inset-0 z-[60] flex items-center justify-center bg-background">
+    <div
+      role="status"
+      className="fixed inset-0 z-[60] flex items-center justify-center bg-background"
+    >
       <svg
         className="bc-loader size-24"
         viewBox="0 0 512 512"
         fill="none"
-        role="img"
-        aria-label="로딩 중"
+        aria-hidden="true"
       >
         <rect className="bar-v" x="90" y="90" width="68" height="200" rx="12" />
         <rect
@@ -24,6 +26,7 @@ export function CardLoadingMotion() {
         />
         <circle className="dot" cx="124" cy="386" r="34" />
       </svg>
+      <span className="sr-only">로딩 중</span>
     </div>
   )
 }

--- a/src/components/home/CardLoadingMotion.tsx
+++ b/src/components/home/CardLoadingMotion.tsx
@@ -1,0 +1,29 @@
+/**
+ * 홈 3D 명함(BusinessCard) 번들 로딩 동안 표시되는 로고 모션.
+ * favicon 로고(세로 막대·가로 막대·빨간 점)를 순차로 그리고 점을 펄스시킨다.
+ * 모션 정의는 globals.css의 `.bc-loader` 참고.
+ */
+export function CardLoadingMotion() {
+  return (
+    <div className="fixed inset-0 z-[60] flex items-center justify-center bg-background">
+      <svg
+        className="bc-loader size-24"
+        viewBox="0 0 512 512"
+        fill="none"
+        role="img"
+        aria-label="로딩 중"
+      >
+        <rect className="bar-v" x="90" y="90" width="68" height="200" rx="12" />
+        <rect
+          className="bar-h"
+          x="222"
+          y="354"
+          width="200"
+          height="68"
+          rx="12"
+        />
+        <circle className="dot" cx="124" cy="386" r="34" />
+      </svg>
+    </div>
+  )
+}


### PR DESCRIPTION
## 🚀 변경 사항

- 홈 3D 명함 초기 로딩 모션 추가 (favicon 로고 기반)
  - 최초 로드에만 풀스크린 노출, SPA 재방문 시 즉시 렌더
  - 3D 준비 완료와 최소 노출 시간(0.666s)을 모두 충족할 때까지 오버레이 유지
  - 로딩 오버레이 접근성 및 onReady 참조 개선

🤖 Generated with [Claude Code](https://claude.com/claude-code)