### PR TITLE
style: 홈 로딩 모션 노출 시간 상향 및 z-index 조정

### DIFF
--- a/src/components/home/BusinessCard.tsx
+++ b/src/components/home/BusinessCard.tsx
@@ -88,6 +88,8 @@ function BusinessCard({ onReady }: { onReady?: () => void }) {
           distanceFactor={1}
           position={[0, 0, 0.51]}
           transform
+          // 기본 z-index가 매우 높아(최대 16777271) 로딩 오버레이(z-60) 위로 새어 나옴 → 범위를 낮춤
+          zIndexRange={[40, 0]}
           style={{
             width: 372,
             height: 356,

--- a/src/components/home/BusinessCardLoader.tsx
+++ b/src/components/home/BusinessCardLoader.tsx
@@ -1,16 +1,16 @@
 'use client'
 
-import dynamic from 'next/dynamic'
 import { useCallback, useEffect, useState } from 'react'
 
 import { CardLoadingMotion } from '@/components/home/CardLoadingMotion'
 import { Spinner } from '@/components/ui/spinner'
+import dynamic from 'next/dynamic'
 
 /**
  * 로딩 모션 최소 노출 시간(ms).
  * 인트로(막대+원 팝업, ~0.666s) 완성 후 펄스 1회 여운까지 보여주기 위해 여유를 둔다.
  */
-const MIN_VISIBLE_MS = 1700
+const MIN_VISIBLE_MS = 1400
 
 /**
  * 이 세션(페이지 로드)에서 홈을 이미 봤는지.

--- a/src/components/home/BusinessCardLoader.tsx
+++ b/src/components/home/BusinessCardLoader.tsx
@@ -6,8 +6,11 @@ import { useCallback, useEffect, useState } from 'react'
 import { CardLoadingMotion } from '@/components/home/CardLoadingMotion'
 import { Spinner } from '@/components/ui/spinner'
 
-/** 로딩 모션 최소 노출 시간(ms). 막대 그리기 + 원 팝업 완료 시점(템포 0.9s 기준 약 0.666s). */
-const MIN_VISIBLE_MS = 666
+/**
+ * 로딩 모션 최소 노출 시간(ms).
+ * 인트로(막대+원 팝업, ~0.666s) 완성 후 펄스 1회 여운까지 보여주기 위해 여유를 둔다.
+ */
+const MIN_VISIBLE_MS = 1700
 
 /**
  * 이 세션(페이지 로드)에서 홈을 이미 봤는지.
@@ -47,14 +50,12 @@ export default function BusinessCardLoader() {
 
   const handleReady = useCallback(() => setReady(true), [])
 
-  // 최초 로드에만, 최소 노출 시간과 3D 준비가 모두 끝날 때까지 모션을 유지한다.
-  // (스피너가 드러날 틈이 없도록 오버레이가 준비 완료까지 덮음)
-  const showMotion = firstLoad && !(minElapsed && ready)
-
+  // 최초 로드에만 표시. 최소 노출 시간과 3D 준비가 모두 끝나면 페이드아웃한다.
+  // (오버레이는 준비 완료까지 덮어 스피너가 드러날 틈을 없앤다)
   return (
     <>
       <BusinessCardCanvas onReady={handleReady} />
-      {showMotion && <CardLoadingMotion />}
+      {firstLoad && <CardLoadingMotion hidden={minElapsed && ready} />}
     </>
   )
 }

--- a/src/components/home/CardLoadingMotion.tsx
+++ b/src/components/home/CardLoadingMotion.tsx
@@ -1,13 +1,21 @@
+import { cn } from '@/lib/utils/cn'
+
 /**
  * 홈 3D 명함(BusinessCard) 번들 로딩 동안 표시되는 로고 모션.
  * favicon 로고(세로 막대·가로 막대·빨간 점)를 순차로 그리고 점을 펄스시킨다.
  * 모션 정의는 globals.css의 `.bc-loader` 참고.
+ *
+ * hidden=true가 되면 opacity로 페이드아웃한다(클릭 통과·스크린리더 숨김).
  */
-export function CardLoadingMotion() {
+export function CardLoadingMotion({ hidden = false }: { hidden?: boolean }) {
   return (
     <div
       role="status"
-      className="fixed inset-0 z-[60] flex items-center justify-center bg-background"
+      aria-hidden={hidden}
+      className={cn(
+        'fixed inset-0 z-[60] flex items-center justify-center bg-background transition-opacity duration-300',
+        hidden && 'pointer-events-none opacity-0',
+      )}
     >
       <svg
         className="bc-loader size-24"


### PR DESCRIPTION
## 🚀 변경 사항

- 로딩 모션 최소 노출 시간 666ms → 1400ms (인트로 완성 + 펄스 여운)
- 로딩 완료 시 페이드아웃(opacity transition) 추가
- 명함 `<Html>`의 zIndexRange를 낮춰 로딩 오버레이 아래로 배치 (오버레이 위로 새어 나오던 문제 해결)

## 🔗 관련 이슈

- Closes #136

## 📝 메모 (선택)

- drei `<Html>`은 기본 z-index가 매우 높아(최대 16777271) 로딩 오버레이를 뚫고 보였음 → `zIndexRange={[40, 0]}`로 조정

🤖 Generated with [Claude Code](https://claude.com/claude-code)