### PR TITLE
chore: MDX 렌더 캐시 적용 및 Toaster 정리

### DIFF
--- a/src/app/blog/layout.tsx
+++ b/src/app/blog/layout.tsx
@@ -1,9 +1,17 @@
 import type { ReactNode } from 'react'
 
+import { Toaster } from 'sonner'
+
 interface BlogLayoutProps {
   children: ReactNode
 }
 
 export default function BlogLayout({ children }: BlogLayoutProps) {
-  return <div className="relative w-full">{children}</div>
+  return (
+    <div className="relative w-full">
+      {children}
+      {/* 토스트 알림 (공유/코드 복사 — blog에서만 사용) */}
+      <Toaster position="top-right" offset={{ top: 'var(--header-height)' }} />
+    </div>
+  )
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -12,7 +12,6 @@ import type { Metadata } from 'next'
 import { ReactNode } from 'react'
 import { SITE_CONFIG } from '@/lib/constants/site'
 import ScrollToTopButton from '@/components/shared/ScrollToTopButton'
-import { Toaster } from 'sonner'
 
 interface RootLayoutProps {
   children: ReactNode
@@ -105,13 +104,6 @@ export default function RootLayout({ children }: RootLayoutProps) {
           </main>
           {/* 스크롤 탑 버튼 */}
           <ScrollToTopButton />
-          {/* 토스트 알림 */}
-          <Toaster
-            position="top-right"
-            offset={{
-              top: 'var(--header-height)',
-            }}
-          />
         </div>
       </body>
     </html>

--- a/src/lib/server/mdx.ts
+++ b/src/lib/server/mdx.ts
@@ -1,5 +1,6 @@
 import type { ParsedPost, PostFrontmatter, TocItem } from '@/types/blog'
 
+import { cache } from 'react'
 import { compileMDX } from 'next-mdx-remote/rsc'
 import fs from 'fs'
 import { mdxComponents } from '@/components/blog/mdx'
@@ -33,9 +34,10 @@ function extractToc(source: string): TocItem[] {
   return toc
 }
 
-export async function parseMarkdownFile<T = PostFrontmatter>(
-  filePath: string,
-): Promise<ParsedPost<T>> {
+// 같은 파일에 대한 generateMetadata + 페이지 렌더의 중복 컴파일을 요청 단위로 제거
+export const parseMarkdownFile = cache(async function parseMarkdownFile<
+  T = PostFrontmatter,
+>(filePath: string): Promise<ParsedPost<T>> {
   // 파일 읽기
   let source: string
   try {
@@ -86,4 +88,4 @@ export async function parseMarkdownFile<T = PostFrontmatter>(
     const message = error instanceof Error ? error.message : 'Unknown error'
     throw new Error(`MDX 컴파일 실패: ${filePath}\n${message}`)
   }
-}
+})

--- a/src/lib/server/posts.ts
+++ b/src/lib/server/posts.ts
@@ -1,3 +1,4 @@
+import { cache } from 'react'
 import fs from 'fs'
 import path from 'path'
 import matter from 'gray-matter'
@@ -6,7 +7,7 @@ import { formatDate } from '@/lib/utils/format'
 
 const postsDirectory = path.join(process.cwd(), 'src/content/posts')
 
-export function getAllPosts(): Post[] {
+export const getAllPosts = cache(function getAllPosts(): Post[] {
   // 디렉토리 존재 여부 확인
   if (!fs.existsSync(postsDirectory)) {
     console.warn(`Posts directory not found: ${postsDirectory}`)
@@ -44,4 +45,4 @@ export function getAllPosts(): Post[] {
 
   // 날짜 기준 내림차순 정렬
   return posts.sort((a, b) => (a.date < b.date ? 1 : -1))
-}
+})


### PR DESCRIPTION
## 🚀 변경 사항

- MDX 이중 컴파일 제거 — `parseMarkdownFile`·`getAllPosts`에 react `cache()` 적용 (generateMetadata + 페이지 렌더가 같은 파일을 2번 컴파일·파싱하던 것을 요청 단위로 제거)
- 전역 `Toaster`를 blog 레이아웃으로 이동 — 토스트는 blog(공유·코드 복사)에서만 쓰이므로 blog 외 페이지 번들에서 분리

## 🔗 관련 이슈

- Closes #143

## 📝 메모 (선택)

- 폰트 subset 최적화는 subset 파일에 weight(bold/semibold)가 빠져 있어 제외 — 별도 후속 작업으로 분리(계획서 P1-1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)