### PR TITLE
fix: TOC 앵커 id 불일치 및 명함 로딩 fallback 수정

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "@tailwindcss/typography": "^0.5.16",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "github-slugger": "^2.0.0",
     "glob": "^11.0.3",
     "gray-matter": "^4.0.3",
     "lucide-react": "^0.544.0",

--- a/src/components/home/BusinessCard.tsx
+++ b/src/components/home/BusinessCard.tsx
@@ -82,7 +82,7 @@ function BusinessCard({ onReady }: { onReady?: () => void }) {
     <mesh ref={meshRef} scale={responsiveScale}>
       <boxGeometry />
       <meshBasicMaterial map={texture} toneMapped={false} />
-      <Suspense fallback="명함 컴포넌트">
+      <Suspense fallback={null}>
         <Html
           occlude
           distanceFactor={1}

--- a/src/lib/server/mdx.ts
+++ b/src/lib/server/mdx.ts
@@ -3,6 +3,7 @@ import type { ParsedPost, PostFrontmatter, TocItem } from '@/types/blog'
 import { cache } from 'react'
 import { compileMDX } from 'next-mdx-remote/rsc'
 import fs from 'fs'
+import GithubSlugger from 'github-slugger'
 import { mdxComponents } from '@/components/blog/mdx'
 import rehypePrettyCode from 'rehype-pretty-code'
 import rehypeSlug from 'rehype-slug'
@@ -12,21 +13,21 @@ import remarkGfm from 'remark-gfm'
 import getReadingTime from 'reading-time'
 
 /**
- * 마크다운 소스에서 heading을 추출하여 목차 생성
+ * 마크다운 소스에서 heading을 추출하여 목차 생성.
+ * 실제 헤딩 id는 rehype-slug가 부여하므로, 동일한 github-slugger로 id를 만들어
+ * 목차 링크(href)와 헤딩 id가 어긋나지 않게 한다.
  */
 function extractToc(source: string): TocItem[] {
   const headingRegex = /^(#{1,6})\s+(.+)$/gm
+  // rehype-slug와 동일하게 문서 단위 인스턴스로 slug 생성 (중복 heading은 -1 접미)
+  const slugger = new GithubSlugger()
   const toc: TocItem[] = []
 
   let match
   while ((match = headingRegex.exec(source)) !== null) {
     const level = match[1].length
     const text = match[2].trim()
-    // rehype-slug와 동일한 방식으로 id 생성
-    const id = text
-      .toLowerCase()
-      .replace(/[^a-z0-9가-힣\s-]/g, '')
-      .replace(/\s+/g, '-')
+    const id = slugger.slug(text)
 
     toc.push({ id, text, level })
   }

--- a/src/lib/utils/format.ts
+++ b/src/lib/utils/format.ts
@@ -8,14 +8,11 @@ export function formatDate(dateString: string): string {
 
   try {
     const date = new Date(dateString)
-    return date
-      .toLocaleDateString('ko-KR', {
-        year: 'numeric',
-        month: '2-digit',
-        day: '2-digit',
-      })
-      .replace(/\./g, '.')
-      .replace(/\s/g, ' ')
+    return date.toLocaleDateString('ko-KR', {
+      year: 'numeric',
+      month: '2-digit',
+      day: '2-digit',
+    })
   } catch {
     return dateString
   }
@@ -24,7 +21,7 @@ export function formatDate(dateString: string): string {
 /**
  * 날짜 문자열을 ISO8601 형식으로 변환
  * @param dateString - YYYY-MM-DD 형식의 날짜 문자열 또는 이미 ISO8601 형식인 문자열
- * @returns ISO8601 형식의 날짜 문자열 (YYYY-MM-DDTHH:mm:ss.sssZ)
+ * @returns ISO8601 형식의 날짜 문자열, 유효하지 않으면 빈 문자열
  */
 export function toISO8601(dateString: string): string {
   if (!dateString) return ''
@@ -37,10 +34,10 @@ export function toISO8601(dateString: string): string {
   // YYYY-MM-DD 형식을 ISO8601로 변환
   const date = new Date(dateString)
 
-  // 유효하지 않은 날짜 체크
+  // 유효하지 않은 날짜는 구조화 데이터(JSON-LD) 오염을 막기 위해 빈 문자열 반환
   if (isNaN(date.getTime())) {
     console.error(`Invalid date string: ${dateString}`)
-    return dateString
+    return ''
   }
 
   return date.toISOString()

--- a/src/lib/utils/mdx.ts
+++ b/src/lib/utils/mdx.ts
@@ -1,16 +1,15 @@
 import { ReactNode, isValidElement } from 'react'
+import GithubSlugger from 'github-slugger'
 
 /**
  * 텍스트에서 heading ID를 생성합니다.
+ * 실제 헤딩 id를 부여하는 rehype-slug와 동일한 github-slugger를 사용해,
+ * rehype-slug가 id를 채우지 못한 경우의 폴백으로도 일관된 값을 만듭니다.
  * @param text - 변환할 텍스트
- * @returns kebab-case 형식의 ID
+ * @returns slug 형식의 ID
  */
 export function generateHeadingId(text: string): string {
-  return text
-    .toString()
-    .toLowerCase()
-    .replace(/\s+/g, '-')
-    .replace(/[^\w\-가-힣]/g, '')
+  return new GithubSlugger().slug(text)
 }
 
 /**


### PR DESCRIPTION
## 🚀 변경 사항

- **TOC 앵커 id 불일치 수정** — extractToc·generateHeadingId의 자체 정규식을 rehype-slug와 동일한 `github-slugger`로 통일. 실제 헤딩 id와 목차 링크가 어긋나던 문제 해결 (110개 heading 중 `"그리드 1칸 = 실물 1mm"` 1건에서 실제 발생 확인)
- **명함 로딩 fallback** — Suspense fallback을 `"명함 컴포넌트"` 개발용 문자열에서 `null`로 교체
- **날짜 처리** — `toISO8601`이 유효하지 않은 날짜에 빈 문자열 반환(구조화 데이터 오염 방지), `formatDate`의 no-op `.replace` 제거

## 🔗 관련 이슈

- Closes #145

## 📝 메모 (선택)

- `github-slugger`는 rehype-slug의 transitive 의존이라 yarn.lock 변경 없이 package.json에 직접 명시만 추가
- 확인 요망: care-label-editor 글의 "그리드 1칸 = 실물 1mm" 목차 클릭 시 정확히 이동하는지

🤖 Generated with [Claude Code](https://claude.com/claude-code)