### PR TITLE
refactor: 콘텐츠 데이터 레이어 정리

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
     "postcss": "^8.5.6",
     "react": "^19.2.3",
     "react-dom": "^19.2.3",
-    "reading-time": "^1.5.0",
     "rehype-pretty-code": "^0.14.1",
     "rehype-slug": "^6.0.0",
     "rehype-unwrap-images": "^1.0.0",

--- a/src/app/blog/[id]/page.tsx
+++ b/src/app/blog/[id]/page.tsx
@@ -11,10 +11,8 @@ import type { Metadata } from 'next'
 import { SITE_CONFIG } from '@/lib/constants/site'
 import { ShareButton } from '@/components/blog/ShareButton'
 import { TableOfContents } from '@/components/blog/TableOfContents'
-import { getAllPosts } from '@/lib/server/posts'
+import { getAllPosts, getPostById, getPostContent } from '@/lib/server/posts'
 import { notFound } from 'next/navigation'
-import { parseMarkdownFile } from '@/lib/server/mdx'
-import path from 'path'
 
 interface BlogPageProps {
   params: Promise<{ id: string }>
@@ -25,8 +23,7 @@ export async function generateMetadata({
   params,
 }: BlogPageProps): Promise<Metadata> {
   const { id: postId } = await params
-  const allPosts = getAllPosts()
-  const post = allPosts.find((p) => p.id === postId)
+  const post = getPostById(postId)
 
   if (!post) {
     return {
@@ -34,9 +31,7 @@ export async function generateMetadata({
     }
   }
 
-  // 포스트 파일 경로 생성하고 파싱
-  const postPath = path.join(process.cwd(), 'src/content/posts', `${postId}.md`)
-  const { frontmatter } = await parseMarkdownFile(postPath)
+  const { frontmatter } = await getPostContent(postId)
 
   const ogImage = frontmatter.thumbnail || SITE_CONFIG.images.ogImage
 
@@ -80,16 +75,13 @@ export default async function BlogPage({ params }: BlogPageProps) {
   const { id: postId } = await params
 
   // 해당 ID의 포스트가 존재하는지 확인
-  const allPosts = getAllPosts()
-  const post = allPosts.find((p) => p.id === postId)
+  const post = getPostById(postId)
 
   if (!post) {
     notFound()
   }
 
-  // 포스트 파일 경로 생성하고 파싱
-  const postPath = path.join(process.cwd(), 'src/content/posts', `${postId}.md`)
-  const { frontmatter, content, toc } = await parseMarkdownFile(postPath)
+  const { frontmatter, content, toc } = await getPostContent(postId)
 
   // JSON-LD 구조화된 데이터 생성
   const jsonLd = {

--- a/src/app/projects/[slug]/page.tsx
+++ b/src/app/projects/[slug]/page.tsx
@@ -1,11 +1,12 @@
 import type { Metadata } from 'next'
-import type { ProjectFrontmatter } from '@/types/project'
 import { SITE_CONFIG } from '@/lib/constants/site'
 import { TableOfContents } from '@/components/blog/TableOfContents'
-import { getAllProjects } from '@/lib/server/projects'
+import {
+  getAllProjects,
+  getProjectBySlug,
+  getProjectContent,
+} from '@/lib/server/projects'
 import { notFound } from 'next/navigation'
-import { parseMarkdownFile } from '@/lib/server/mdx'
-import path from 'path'
 import { toAbsoluteUrl } from '@/lib/utils/format'
 
 interface ProjectPageProps {
@@ -17,8 +18,7 @@ export async function generateMetadata({
   params,
 }: ProjectPageProps): Promise<Metadata> {
   const { slug } = await params
-  const projects = getAllProjects()
-  const project = projects.find((p) => p.slug === slug)
+  const project = getProjectBySlug(slug)
 
   if (!project) {
     return {
@@ -26,14 +26,7 @@ export async function generateMetadata({
     }
   }
 
-  // 프로젝트 기록 파일 경로 생성하고 파싱
-  const projectPath = path.join(
-    process.cwd(),
-    'src/content/projects',
-    `${slug}.md`,
-  )
-  const { frontmatter } =
-    await parseMarkdownFile<ProjectFrontmatter>(projectPath)
+  const { frontmatter } = await getProjectContent(slug)
 
   const ogImage = SITE_CONFIG.images.ogImage
 
@@ -74,21 +67,13 @@ export default async function ProjectDetailPage({ params }: ProjectPageProps) {
   const { slug } = await params
 
   // 해당 slug의 프로젝트 기록이 존재하는지 확인
-  const projects = getAllProjects()
-  const project = projects.find((p) => p.slug === slug)
+  const project = getProjectBySlug(slug)
 
   if (!project) {
     notFound()
   }
 
-  // 프로젝트 기록 파일 경로 생성하고 파싱
-  const projectPath = path.join(
-    process.cwd(),
-    'src/content/projects',
-    `${slug}.md`,
-  )
-  const { frontmatter, content, toc } =
-    await parseMarkdownFile<ProjectFrontmatter>(projectPath)
+  const { frontmatter, content, toc } = await getProjectContent(slug)
 
   return (
     <div className="relative w-full pt-20 pb-12">

--- a/src/lib/server/collection.ts
+++ b/src/lib/server/collection.ts
@@ -1,0 +1,39 @@
+import fs from 'fs'
+import path from 'path'
+import matter from 'gray-matter'
+
+/**
+ * 마크다운 컬렉션 로더 뼈대.
+ * 디렉토리의 `.md` 파일을 읽어 frontmatter를 파싱하고, `map`으로 항목을 만든 뒤 `sort`로 정렬한다.
+ * 개별 파일 파싱 실패는 로깅 후 건너뛴다(부분 목록 반환).
+ *
+ * @param directory 콘텐츠 디렉토리 절대 경로
+ * @param map 파일 id(확장자 제외)와 frontmatter 데이터로 항목 생성
+ * @param sort 정렬 비교 함수
+ */
+export function loadMarkdownCollection<T>(
+  directory: string,
+  map: (id: string, data: Record<string, any>) => T,
+  sort: (a: T, b: T) => number,
+): T[] {
+  if (!fs.existsSync(directory)) {
+    console.warn(`Content directory not found: ${directory}`)
+    return []
+  }
+
+  const items: T[] = []
+  for (const fileName of fs.readdirSync(directory)) {
+    if (!fileName.endsWith('.md')) continue
+    try {
+      const id = fileName.replace(/\.md$/, '')
+      const fullPath = path.join(directory, fileName)
+      const { data } = matter(fs.readFileSync(fullPath, 'utf8'))
+      items.push(map(id, data))
+    } catch (error) {
+      // 개별 파일 에러는 로깅 후 건너뛰기
+      console.error(`Failed to parse markdown: ${fileName}`, error)
+    }
+  }
+
+  return items.sort(sort)
+}

--- a/src/lib/server/mdx.ts
+++ b/src/lib/server/mdx.ts
@@ -10,7 +10,6 @@ import rehypeSlug from 'rehype-slug'
 import rehypeUnwrapImages from 'rehype-unwrap-images'
 import remarkBreaks from 'remark-breaks'
 import remarkGfm from 'remark-gfm'
-import getReadingTime from 'reading-time'
 
 /**
  * 마크다운 소스에서 heading을 추출하여 목차 생성.
@@ -48,10 +47,6 @@ export const parseMarkdownFile = cache(async function parseMarkdownFile<
     throw new Error(`마크다운 파일을 읽을 수 없습니다: ${filePath}\n${message}`)
   }
 
-  // 읽기 시간 계산
-  const { minutes } = getReadingTime(source)
-  const readingTime = Math.ceil(minutes)
-
   // 목차 추출
   const toc = extractToc(source)
 
@@ -82,7 +77,6 @@ export const parseMarkdownFile = cache(async function parseMarkdownFile<
     return {
       frontmatter,
       content,
-      readingTime,
       toc,
     }
   } catch (error) {

--- a/src/lib/server/posts.ts
+++ b/src/lib/server/posts.ts
@@ -1,48 +1,36 @@
 import { cache } from 'react'
-import fs from 'fs'
 import path from 'path'
-import matter from 'gray-matter'
 import type { Post } from '@/types/blog'
 import { formatDate } from '@/lib/utils/format'
+import { parseMarkdownFile } from '@/lib/server/mdx'
+import { loadMarkdownCollection } from '@/lib/server/collection'
 
 const postsDirectory = path.join(process.cwd(), 'src/content/posts')
 
-export const getAllPosts = cache(function getAllPosts(): Post[] {
-  // 디렉토리 존재 여부 확인
-  if (!fs.existsSync(postsDirectory)) {
-    console.warn(`Posts directory not found: ${postsDirectory}`)
-    return []
-  }
+// 전체 포스트 목록 (날짜 내림차순)
+export const getAllPosts = cache(() =>
+  loadMarkdownCollection<Post>(
+    postsDirectory,
+    (id, data) => ({
+      id,
+      title: data.title || '',
+      description: data.description || '',
+      date: formatDate(data.date) || '',
+      category: data.category || 'uncategorized',
+      tags: data.tags || [],
+      thumbnail: data.thumbnail,
+    }),
+    (a, b) => (a.date < b.date ? 1 : -1),
+  ),
+)
 
-  // posts 디렉토리의 모든 .md 파일 읽기
-  const fileNames = fs.readdirSync(postsDirectory)
-  const mdFiles = fileNames.filter((name) => name.endsWith('.md'))
+// id로 단일 포스트 조회 (없으면 undefined)
+export const getPostById = cache((id: string) =>
+  getAllPosts().find((post) => post.id === id),
+)
 
-  const posts: Post[] = []
-
-  for (const fileName of mdFiles) {
-    try {
-      const id = fileName.replace(/\.md$/, '')
-      const fullPath = path.join(postsDirectory, fileName)
-      const fileContents = fs.readFileSync(fullPath, 'utf8')
-      const { data } = matter(fileContents)
-
-      posts.push({
-        id,
-        title: data.title || '',
-        description: data.description || '',
-        date: formatDate(data.date) || '',
-        category: data.category || 'uncategorized',
-        tags: data.tags || [],
-        readingTime: data.readingTime,
-        thumbnail: data.thumbnail,
-      } as Post)
-    } catch (error) {
-      // 개별 파일 에러는 로깅 후 건너뛰기
-      console.error(`Failed to parse post: ${fileName}`, error)
-    }
-  }
-
-  // 날짜 기준 내림차순 정렬
-  return posts.sort((a, b) => (a.date < b.date ? 1 : -1))
-})
+// 상세 페이지용: id로 콘텐츠(frontmatter/content/toc) 파싱
+// parseMarkdownFile이 요청 단위로 캐시되므로 별도 cache 불필요
+export function getPostContent(id: string) {
+  return parseMarkdownFile(path.join(postsDirectory, `${id}.md`))
+}

--- a/src/lib/server/projects.ts
+++ b/src/lib/server/projects.ts
@@ -1,49 +1,34 @@
-import fs from 'fs'
-import path from 'path'
 import { cache } from 'react'
-import matter from 'gray-matter'
-import type { Project } from '@/types/project'
+import path from 'path'
+import type { Project, ProjectFrontmatter } from '@/types/project'
+import { parseMarkdownFile } from '@/lib/server/mdx'
+import { loadMarkdownCollection } from '@/lib/server/collection'
 
 const projectsDirectory = path.join(process.cwd(), 'src/content/projects')
 
-export const getAllProjects = cache(function getAllProjects(): Project[] {
-  // 디렉토리 존재 여부 확인
-  if (!fs.existsSync(projectsDirectory)) {
-    console.warn(`Projects directory not found: ${projectsDirectory}`)
-    return []
-  }
-
-  // projects 디렉토리의 모든 .md 파일 읽기
-  const fileNames = fs.readdirSync(projectsDirectory)
-  const mdFiles = fileNames.filter((name) => name.endsWith('.md'))
-
-  const projects: Project[] = []
-
-  for (const fileName of mdFiles) {
-    try {
-      const slug = fileName.replace(/\.md$/, '')
-      const fullPath = path.join(projectsDirectory, fileName)
-      const fileContents = fs.readFileSync(fullPath, 'utf8')
-      const { data } = matter(fileContents)
-
-      projects.push({
-        slug,
-        label: data.label || '',
-        title: data.title || '',
-        description: data.description || '',
-        order: data.order ?? 0,
-      } as Project)
-    } catch (error) {
-      // 개별 파일 에러는 로깅 후 건너뛰기
-      console.error(`Failed to parse project: ${fileName}`, error)
-    }
-  }
-
-  // order 기준 오름차순 정렬
-  return projects.sort((a, b) => a.order - b.order)
-})
+// 전체 프로젝트 목록 (order 오름차순)
+export const getAllProjects = cache(() =>
+  loadMarkdownCollection<Project>(
+    projectsDirectory,
+    (slug, data) => ({
+      slug,
+      label: data.label || '',
+      title: data.title || '',
+      description: data.description || '',
+      order: data.order ?? 0,
+    }),
+    (a, b) => a.order - b.order,
+  ),
+)
 
 // slug로 단일 프로젝트 조회 (없으면 undefined)
-export const getProjectBySlug = cache((slug: string): Project | undefined =>
+export const getProjectBySlug = cache((slug: string) =>
   getAllProjects().find((project) => project.slug === slug),
 )
+
+// 상세 페이지용: slug로 콘텐츠(frontmatter/content/toc) 파싱
+export function getProjectContent(slug: string) {
+  return parseMarkdownFile<ProjectFrontmatter>(
+    path.join(projectsDirectory, `${slug}.md`),
+  )
+}

--- a/src/types/blog.ts
+++ b/src/types/blog.ts
@@ -5,7 +5,6 @@ export interface Post {
   date: string
   category?: string
   tags: string[]
-  readingTime?: number
   thumbnail?: string
 }
 
@@ -28,6 +27,5 @@ export interface TocItem {
 export interface ParsedPost<T = PostFrontmatter> {
   frontmatter: T
   content: React.ReactElement
-  readingTime: number
   toc: TocItem[]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4607,11 +4607,6 @@ react@^19.2.3:
   resolved "https://registry.yarnpkg.com/react/-/react-19.2.3.tgz#d83e5e8e7a258cf6b4fe28640515f99b87cd19b8"
   integrity sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==
 
-reading-time@^1.5.0:
-  version "1.5.0"
-  resolved "https://registry.yarnpkg.com/reading-time/-/reading-time-1.5.0.tgz#d2a7f1b6057cb2e169beaf87113cc3411b5bc5bb"
-  integrity sha512-onYyVhBNr4CmAxFsKS7bz+uTLRakypIe4R+5A824vBSkQy/hB3fZepoVEf8OVAxzLvK+H/jm9TzpI3ETSm64Kg==
-
 recma-build-jsx@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/recma-build-jsx/-/recma-build-jsx-1.0.0.tgz#c02f29e047e103d2fab2054954e1761b8ea253c4"


### PR DESCRIPTION
## 🚀 변경 사항

- **공통 로더 도입** — `loadMarkdownCollection<T>(dir, map, sort)` 신설, posts/projects의 읽기·파싱·정렬·에러처리 뼈대 중복 제거
- **콘텐츠 헬퍼 추가** — `getPostById`·`getPostContent`, `getProjectContent` (기존 `getProjectBySlug`와 대칭). 상세 페이지의 `path.join` 경로 조립과 `getAllX().find` 직접 호출 제거
- **캐시 경유 통일** — projects 상세가 캐시된 `getProjectBySlug`를 우회하던 것을 헬퍼 경유로 변경
- **readingTime 제거** — 계산만 하고 노출하지 않던 dead code 정리 (mdx 계산, `Post`·`ParsedPost` 타입, `reading-time` 의존성)

## 🔗 관련 이슈

- Closes #147

## 📝 메모 (선택)

- 공통 로더는 셸(디렉토리 순회·파싱·정렬)만 공통화하고 매핑·정렬은 각 도메인이 주입 — 과도한 추상화 지양
- 빌드(SSG) 통과로 blog/projects 상세 정적 생성 정상 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)