### PR TITLE
refactor: 상세 페이지 셸 및 메타데이터 공통화

### DIFF
--- a/src/app/blog/[id]/page.tsx
+++ b/src/app/blog/[id]/page.tsx
@@ -1,17 +1,18 @@
-import { formatDate, toAbsoluteUrl } from '@/lib/utils/format'
 import {
+  buildDetailMetadata,
   generateBlogPostingSchema,
   generateBreadcrumbSchema,
   serializeJsonLd,
 } from '@/lib/utils/seo'
+import { formatDate, toAbsoluteUrl } from '@/lib/utils/format'
+import { getAllPosts, getPostById, getPostContent } from '@/lib/server/posts'
 
 import { CATEGORY_NAMES } from '@/lib/constants/blog'
+import { DetailLayout } from '@/components/shared/DetailLayout'
 import Giscus from '@/components/blog/Giscus'
 import type { Metadata } from 'next'
 import { SITE_CONFIG } from '@/lib/constants/site'
 import { ShareButton } from '@/components/blog/ShareButton'
-import { TableOfContents } from '@/components/blog/TableOfContents'
-import { getAllPosts, getPostById, getPostContent } from '@/lib/server/posts'
 import { notFound } from 'next/navigation'
 
 interface BlogPageProps {
@@ -33,48 +34,18 @@ export async function generateMetadata({
 
   const { frontmatter } = await getPostContent(postId)
 
-  const ogImage = frontmatter.thumbnail || SITE_CONFIG.images.ogImage
-
-  return {
+  return buildDetailMetadata({
     title: frontmatter.title,
-    description: frontmatter.description || frontmatter.title,
-    keywords: frontmatter.tags,
-    authors: [{ name: SITE_CONFIG.author.name }],
-    alternates: {
-      canonical: toAbsoluteUrl(`/blog/${postId}`),
-    },
-    openGraph: {
-      title: frontmatter.title,
-      description: frontmatter.description || frontmatter.title,
-      url: `/blog/${postId}`,
-      siteName: SITE_CONFIG.name,
-      type: 'article',
-      publishedTime: frontmatter.date,
-      authors: [SITE_CONFIG.author.name],
-      tags: frontmatter.tags,
-      images: [
-        {
-          url: ogImage,
-          width: 1200,
-          height: 630,
-          alt: frontmatter.title,
-        },
-      ],
-    },
-    twitter: {
-      card: 'summary_large_image',
-      title: frontmatter.title,
-      description: frontmatter.description || frontmatter.title,
-      images: [ogImage],
-    },
-  }
+    description: frontmatter.description,
+    path: `/blog/${postId}`,
+    ogImage: frontmatter.thumbnail || SITE_CONFIG.images.ogImage,
+    publishedTime: frontmatter.date,
+    tags: frontmatter.tags,
+  })
 }
 
 export default async function BlogPage({ params }: BlogPageProps) {
-  // URL 파라미터에서 포스트 ID 가져오기
   const { id: postId } = await params
-
-  // 해당 ID의 포스트가 존재하는지 확인
   const post = getPostById(postId)
 
   if (!post) {
@@ -88,7 +59,11 @@ export default async function BlogPage({ params }: BlogPageProps) {
     '@context': 'https://schema.org',
     '@graph': [
       generateBlogPostingSchema(postId, frontmatter),
-      generateBreadcrumbSchema(frontmatter.title, postId),
+      generateBreadcrumbSchema([
+        { name: 'Home', path: '/' },
+        { name: 'Blog', path: '/blog' },
+        { name: frontmatter.title, path: `/blog/${postId}` },
+      ]),
     ],
   }
 
@@ -100,52 +75,37 @@ export default async function BlogPage({ params }: BlogPageProps) {
         dangerouslySetInnerHTML={{ __html: serializeJsonLd(jsonLd) }}
       />
 
-      <div className="relative w-full pt-20 pb-12">
-        <div className="section-grid">
-          {/* 왼쪽 목차 */}
-          <aside className="section-left hidden md:block">
-            <div className="sticky top-below-header max-w-aside">
-              <TableOfContents items={toc} />
+      <DetailLayout
+        toc={toc}
+        header={
+          <header>
+            <h1 className="text-2xl font-semibold tracking-tight leading-tight">
+              {frontmatter.title}
+            </h1>
+            <div className="mt-4 flex flex-wrap items-center gap-2 text-sm text-muted-foreground">
+              <span>
+                {CATEGORY_NAMES[frontmatter.category] || frontmatter.category}
+              </span>
+              <span>・</span>
+              <span>{formatDate(frontmatter.date)}</span>
             </div>
-          </aside>
-
-          {/* 메인 콘텐츠 */}
-          <article className="section-right mt-3 md:mt-0 min-w-0">
-            {/* 포스트 헤더 */}
-            <header>
-              {/* 포스트 제목 */}
-              <h1 className="text-2xl font-semibold tracking-tight leading-tight">
-                {frontmatter.title}
-              </h1>
-
-              <div className="mt-4 flex flex-wrap items-center gap-2 text-sm text-muted-foreground">
-                {/* 카테고리 */}
-                <span>
-                  {CATEGORY_NAMES[frontmatter.category] || frontmatter.category}
-                </span>
-                <span>・</span>
-                {/* 작성 날짜 */}
-                <span>{formatDate(frontmatter.date)}</span>
-              </div>
-            </header>
-
-            {/* 포스트 본문 */}
-            <div className="mt-18 prose prose-lg max-w-none prose-gray dark:prose-invert">
-              <div>{content}</div>
-            </div>
-
+          </header>
+        }
+        footer={
+          <>
             {/* 공유 버튼 */}
             <div className="mt-16">
               <ShareButton url={toAbsoluteUrl(`/blog/${postId}`)} />
             </div>
-
-            {/* 포스트 푸터 */}
+            {/* 댓글 */}
             <footer className="mt-16 space-y-6">
               <Giscus />
             </footer>
-          </article>
-        </div>
-      </div>
+          </>
+        }
+      >
+        {content}
+      </DetailLayout>
     </>
   )
 }

--- a/src/app/projects/[slug]/page.tsx
+++ b/src/app/projects/[slug]/page.tsx
@@ -1,13 +1,19 @@
-import type { Metadata } from 'next'
-import { SITE_CONFIG } from '@/lib/constants/site'
-import { TableOfContents } from '@/components/blog/TableOfContents'
+import {
+  buildDetailMetadata,
+  generateBreadcrumbSchema,
+  generateProjectSchema,
+  serializeJsonLd,
+} from '@/lib/utils/seo'
 import {
   getAllProjects,
   getProjectBySlug,
   getProjectContent,
 } from '@/lib/server/projects'
+
+import { DetailLayout } from '@/components/shared/DetailLayout'
+import type { Metadata } from 'next'
+import { SITE_CONFIG } from '@/lib/constants/site'
 import { notFound } from 'next/navigation'
-import { toAbsoluteUrl } from '@/lib/utils/format'
 
 interface ProjectPageProps {
   params: Promise<{ slug: string }>
@@ -28,45 +34,16 @@ export async function generateMetadata({
 
   const { frontmatter } = await getProjectContent(slug)
 
-  const ogImage = SITE_CONFIG.images.ogImage
-
-  return {
+  return buildDetailMetadata({
     title: frontmatter.title,
-    description: frontmatter.description || frontmatter.title,
-    authors: [{ name: SITE_CONFIG.author.name }],
-    alternates: {
-      canonical: toAbsoluteUrl(`/projects/${slug}`),
-    },
-    openGraph: {
-      title: frontmatter.title,
-      description: frontmatter.description || frontmatter.title,
-      url: `/projects/${slug}`,
-      siteName: SITE_CONFIG.name,
-      type: 'article',
-      authors: [SITE_CONFIG.author.name],
-      images: [
-        {
-          url: ogImage,
-          width: 1200,
-          height: 630,
-          alt: frontmatter.title,
-        },
-      ],
-    },
-    twitter: {
-      card: 'summary_large_image',
-      title: frontmatter.title,
-      description: frontmatter.description || frontmatter.title,
-      images: [ogImage],
-    },
-  }
+    description: frontmatter.description,
+    path: `/projects/${slug}`,
+    ogImage: SITE_CONFIG.images.ogImage,
+  })
 }
 
 export default async function ProjectDetailPage({ params }: ProjectPageProps) {
-  // URL 파라미터에서 slug 가져오기
   const { slug } = await params
-
-  // 해당 slug의 프로젝트 기록이 존재하는지 확인
   const project = getProjectBySlug(slug)
 
   if (!project) {
@@ -75,19 +52,30 @@ export default async function ProjectDetailPage({ params }: ProjectPageProps) {
 
   const { frontmatter, content, toc } = await getProjectContent(slug)
 
-  return (
-    <div className="relative w-full pt-20 pb-12">
-      <div className="section-grid">
-        {/* 왼쪽 목차 */}
-        <aside className="section-left hidden md:block">
-          <div className="sticky top-below-header max-w-aside">
-            <TableOfContents items={toc} />
-          </div>
-        </aside>
+  // JSON-LD 구조화된 데이터 생성
+  const jsonLd = {
+    '@context': 'https://schema.org',
+    '@graph': [
+      generateProjectSchema(slug, frontmatter),
+      generateBreadcrumbSchema([
+        { name: 'Home', path: '/' },
+        { name: 'Projects', path: '/projects' },
+        { name: frontmatter.title, path: `/projects/${slug}` },
+      ]),
+    ],
+  }
 
-        {/* 메인 콘텐츠 */}
-        <article className="section-right mt-3 md:mt-0 min-w-0">
-          {/* 헤더 */}
+  return (
+    <>
+      {/* JSON-LD 스크립트 */}
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: serializeJsonLd(jsonLd) }}
+      />
+
+      <DetailLayout
+        toc={toc}
+        header={
           <header>
             <p className="mb-2 text-sm text-muted-foreground">
               {frontmatter.label}
@@ -96,14 +84,11 @@ export default async function ProjectDetailPage({ params }: ProjectPageProps) {
               {frontmatter.title}
             </h1>
           </header>
-
-          {/* 본문 */}
-          <div className="mt-18 prose prose-lg max-w-none prose-gray dark:prose-invert">
-            <div>{content}</div>
-          </div>
-        </article>
-      </div>
-    </div>
+        }
+      >
+        {content}
+      </DetailLayout>
+    </>
   )
 }
 

--- a/src/components/shared/DetailLayout.tsx
+++ b/src/components/shared/DetailLayout.tsx
@@ -1,0 +1,48 @@
+import type { ReactNode } from 'react'
+
+import { TableOfContents } from '@/components/blog/TableOfContents'
+import type { TocItem } from '@/types/blog'
+
+interface DetailLayoutProps {
+  toc: TocItem[]
+  /** 제목 등 본문 위 헤더 */
+  header: ReactNode
+  /** 본문(prose로 래핑됨) */
+  children: ReactNode
+  /** 공유·댓글 등 본문 아래 영역 (선택) */
+  footer?: ReactNode
+}
+
+/**
+ * blog/projects 상세 페이지 공통 셸.
+ * 좌측 sticky 목차 + 우측 article(header · prose 본문 · footer)로 구성한다.
+ * 헤더/푸터 내용은 각 도메인이 slot으로 주입한다.
+ */
+export function DetailLayout({
+  toc,
+  header,
+  children,
+  footer,
+}: DetailLayoutProps) {
+  return (
+    <div className="relative w-full pt-20 pb-12">
+      <div className="section-grid">
+        {/* 왼쪽 목차 */}
+        <aside className="section-left hidden md:block">
+          <div className="sticky top-below-header max-w-aside">
+            <TableOfContents items={toc} />
+          </div>
+        </aside>
+
+        {/* 메인 콘텐츠 */}
+        <article className="section-right mt-3 md:mt-0 min-w-0">
+          {header}
+          <div className="mt-18 prose prose-lg max-w-none prose-gray dark:prose-invert">
+            {children}
+          </div>
+          {footer}
+        </article>
+      </div>
+    </div>
+  )
+}

--- a/src/lib/constants/site.ts
+++ b/src/lib/constants/site.ts
@@ -25,6 +25,7 @@ export const SITE_CONFIG = {
   images: {
     ogImage: '/images/opengraph-image.webp',
     logo: '/images/logo.png',
+    ogSize: { width: 1200, height: 630 },
   },
 
   // 키워드

--- a/src/lib/utils/seo.ts
+++ b/src/lib/utils/seo.ts
@@ -1,11 +1,13 @@
 /**
  * SEO 유틸리티
- * JSON-LD 구조화된 데이터 생성 헬퍼
+ * JSON-LD 구조화된 데이터 및 상세 페이지 메타데이터 생성 헬퍼
  */
 
 import { toAbsoluteUrl, toISO8601 } from './format'
 
+import type { Metadata } from 'next'
 import type { PostFrontmatter } from '@/types/blog'
+import type { ProjectFrontmatter } from '@/types/project'
 import { SITE_CONFIG } from '@/lib/constants/site'
 
 /**
@@ -97,6 +99,35 @@ export function generateBlogPostingSchema(
 }
 
 /**
+ * 프로젝트 기록(Article) 스키마 생성
+ */
+export function generateProjectSchema(
+  slug: string,
+  frontmatter: ProjectFrontmatter,
+) {
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'Article',
+    '@id': `${SITE_CONFIG.url}/projects/${slug}#article`,
+    headline: frontmatter.title,
+    description: frontmatter.description,
+    url: toAbsoluteUrl(`/projects/${slug}`),
+    image: toAbsoluteUrl(SITE_CONFIG.images.ogImage),
+    author: {
+      '@id': `${SITE_CONFIG.url}/resume#person`,
+    },
+    publisher: {
+      '@id': `${SITE_CONFIG.url}#organization`,
+    },
+    mainEntityOfPage: {
+      '@type': 'WebPage',
+      '@id': toAbsoluteUrl(`/projects/${slug}`),
+    },
+    inLanguage: SITE_CONFIG.locale,
+  }
+}
+
+/**
  * ProfilePage 스키마 생성 (Resume 페이지용)
  */
 export function generateProfilePageSchema() {
@@ -115,33 +146,82 @@ export function generateProfilePageSchema() {
 }
 
 /**
- * BreadcrumbList 스키마 생성
+ * BreadcrumbList 스키마 생성.
+ * 세그먼트 목록(name/path)을 받아 도메인(blog/projects)에 무관하게 재사용한다.
  */
-export function generateBreadcrumbSchema(postTitle: string, postId: string) {
+export function generateBreadcrumbSchema(
+  items: { name: string; path: string }[],
+) {
+  const last = items[items.length - 1]
   return {
     '@context': 'https://schema.org',
     '@type': 'BreadcrumbList',
-    '@id': `${SITE_CONFIG.url}/blog/${postId}#breadcrumbs`,
-    itemListElement: [
-      {
-        '@type': 'ListItem',
-        position: 1,
-        name: 'Home',
-        item: toAbsoluteUrl('/'),
-      },
-      {
-        '@type': 'ListItem',
-        position: 2,
-        name: 'Blog',
-        item: toAbsoluteUrl('/blog'),
-      },
-      {
-        '@type': 'ListItem',
-        position: 3,
-        name: postTitle,
-        item: toAbsoluteUrl(`/blog/${postId}`),
-      },
-    ],
+    '@id': `${toAbsoluteUrl(last.path)}#breadcrumbs`,
+    itemListElement: items.map((item, index) => ({
+      '@type': 'ListItem',
+      position: index + 1,
+      name: item.name,
+      item: toAbsoluteUrl(item.path),
+    })),
+  }
+}
+
+interface DetailMetadataInput {
+  title: string
+  description?: string
+  /** 상대 경로 (예: '/blog/xxx') */
+  path: string
+  ogImage: string
+  publishedTime?: string
+  tags?: string[]
+}
+
+/**
+ * 상세 페이지(blog/projects) 공통 메타데이터 조립.
+ * OG/twitter 카드 구성을 한 곳에서 결정한다.
+ */
+export function buildDetailMetadata({
+  title,
+  description,
+  path,
+  ogImage,
+  publishedTime,
+  tags,
+}: DetailMetadataInput): Metadata {
+  const desc = description || title
+
+  return {
+    title,
+    description: desc,
+    keywords: tags,
+    authors: [{ name: SITE_CONFIG.author.name }],
+    alternates: {
+      canonical: toAbsoluteUrl(path),
+    },
+    openGraph: {
+      title,
+      description: desc,
+      url: path,
+      siteName: SITE_CONFIG.name,
+      type: 'article',
+      publishedTime,
+      authors: [SITE_CONFIG.author.name],
+      tags,
+      images: [
+        {
+          url: ogImage,
+          width: SITE_CONFIG.images.ogSize.width,
+          height: SITE_CONFIG.images.ogSize.height,
+          alt: title,
+        },
+      ],
+    },
+    twitter: {
+      card: 'summary_large_image',
+      title,
+      description: desc,
+      images: [ogImage],
+    },
   }
 }
 


### PR DESCRIPTION
## 🚀 변경 사항

- **공통 셸 DetailLayout** — blog/projects 상세의 레이아웃 뼈대(section-grid + sticky TOC + article + prose)를 통합, 헤더/푸터는 slot으로 각 도메인이 주입
- **buildDetailMetadata** — generateMetadata의 OG/twitter 조립 중복을 헬퍼로 일원화, OG 크기(1200×630)를 `SITE_CONFIG.images.ogSize` 상수로 변경
- **breadcrumb 파라미터화** — 'Blog' 하드코딩을 세그먼트 목록 파라미터로 변경해 프로젝트에서도 재사용
- **프로젝트 JSON-LD 추가** — 프로젝트 상세에 Article + BreadcrumbList 스키마 주입

## 🔗 관련 이슈

- Closes #149

## 📝 메모 (선택)

- OG 이미지 소스는 도메인 차이 유지(blog: thumbnail→ogImage, projects: ogImage)하되 조립은 buildDetailMetadata로 통일
- sitemap의 프로젝트 lastModified 정확화는 frontmatter 날짜 필드가 필요해 별도 작업으로 분리
- 빌드(SSG) 통과 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)